### PR TITLE
Implement the register API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,18 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+
+
+	// JWT
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+
+	// Redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/laphayen/homedrive/HomedriveApplication.java
+++ b/src/main/java/com/laphayen/homedrive/HomedriveApplication.java
@@ -5,12 +5,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
 
-@SpringBootApplication(
-		exclude = {
-				DataSourceAutoConfiguration.class,
-				HibernateJpaAutoConfiguration.class
-		}
-)
+@SpringBootApplication
 public class HomedriveApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/laphayen/homedrive/domain/user/controller/UserController.java
+++ b/src/main/java/com/laphayen/homedrive/domain/user/controller/UserController.java
@@ -1,0 +1,22 @@
+package com.laphayen.homedrive.domain.user.controller;
+
+import com.laphayen.homedrive.domain.user.dto.RegisterRequestDto;
+import com.laphayen.homedrive.domain.user.dto.RegisterResponseDto;
+import com.laphayen.homedrive.domain.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @PostMapping("/register")
+    public ResponseEntity<RegisterResponseDto> register(@RequestBody RegisterRequestDto requestDto) {
+        return ResponseEntity.ok(userService.register(requestDto));
+    }
+
+}

--- a/src/main/java/com/laphayen/homedrive/domain/user/dto/RegisterRequestDto.java
+++ b/src/main/java/com/laphayen/homedrive/domain/user/dto/RegisterRequestDto.java
@@ -1,0 +1,13 @@
+package com.laphayen.homedrive.domain.user.dto;
+
+import lombok.Getter;
+
+@Getter
+public class RegisterRequestDto {
+
+    private String username;
+    private String password;
+    private String email;
+    private String code; // 인증 코드 또는 초대 코드 등
+
+}

--- a/src/main/java/com/laphayen/homedrive/domain/user/dto/RegisterResponseDto.java
+++ b/src/main/java/com/laphayen/homedrive/domain/user/dto/RegisterResponseDto.java
@@ -1,0 +1,22 @@
+package com.laphayen.homedrive.domain.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class RegisterResponseDto {
+
+    private String accessToken;
+    private String refreshToken;
+    private UserInfo user;
+
+    @Getter
+    @Builder
+    public static class UserInfo {
+        private Long id;
+        private String username;
+        private String email;
+    }
+
+}

--- a/src/main/java/com/laphayen/homedrive/domain/user/entity/User.java
+++ b/src/main/java/com/laphayen/homedrive/domain/user/entity/User.java
@@ -1,0 +1,28 @@
+package com.laphayen.homedrive.domain.user.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter @Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "users")
+public class User {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true, nullable = false)
+    private String username;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(unique = true, nullable = false)
+    private String email;
+
+    private String role = "USER";
+
+}

--- a/src/main/java/com/laphayen/homedrive/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/laphayen/homedrive/domain/user/repository/UserRepository.java
@@ -1,0 +1,13 @@
+package com.laphayen.homedrive.domain.user.repository;
+
+import com.laphayen.homedrive.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    boolean existsByUsername(String username);
+    boolean existsByEmail(String email);
+    Optional<User> findByUsername(String username);
+
+}

--- a/src/main/java/com/laphayen/homedrive/domain/user/service/UserService.java
+++ b/src/main/java/com/laphayen/homedrive/domain/user/service/UserService.java
@@ -1,0 +1,57 @@
+package com.laphayen.homedrive.domain.user.service;
+
+import com.laphayen.homedrive.domain.user.dto.RegisterRequestDto;
+import com.laphayen.homedrive.domain.user.dto.RegisterResponseDto;
+import com.laphayen.homedrive.domain.user.entity.User;
+import com.laphayen.homedrive.domain.user.repository.UserRepository;
+import com.laphayen.homedrive.global.security.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final StringRedisTemplate redisTemplate;
+
+    // 회원가입
+    public RegisterResponseDto register(RegisterRequestDto request) {
+        if (userRepository.existsByUsername(request.getUsername())) {
+            throw new RuntimeException("이미 존재하는 사용자명입니다.");
+        }
+        if (userRepository.existsByEmail(request.getEmail())) {
+            throw new RuntimeException("이미 사용 중인 이메일입니다.");
+        }
+
+        User user = userRepository.save(User.builder()
+                .username(request.getUsername())
+                .password(passwordEncoder.encode(request.getPassword()))
+                .email(request.getEmail())
+                .role("USER")
+                .build());
+
+        String accessToken = jwtTokenProvider.createAccessToken(user);
+        String refreshToken = jwtTokenProvider.createRefreshToken(user);
+
+        // Redis에 refresh 토큰 저장
+        redisTemplate.opsForValue().set("refresh:" + user.getId(), refreshToken);
+
+        return RegisterResponseDto.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .user(RegisterResponseDto.UserInfo.builder()
+                        .id(user.getId())
+                        .username(user.getUsername())
+                        .email(user.getEmail())
+                        .build())
+                .build();
+    }
+
+}

--- a/src/main/java/com/laphayen/homedrive/global/config/SecurityConfig.java
+++ b/src/main/java/com/laphayen/homedrive/global/config/SecurityConfig.java
@@ -1,0 +1,52 @@
+package com.laphayen.homedrive.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/api/v1/auth/register",
+                                "/api/v1/auth/login"
+                        ).permitAll()
+                        .anyRequest().authenticated()
+                );
+
+        return http.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOriginPatterns(List.of("*"));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+}

--- a/src/main/java/com/laphayen/homedrive/global/security/JwtTokenProvider.java
+++ b/src/main/java/com/laphayen/homedrive/global/security/JwtTokenProvider.java
@@ -1,0 +1,54 @@
+package com.laphayen.homedrive.global.security;
+
+import com.laphayen.homedrive.domain.user.entity.User;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+
+@Component
+public class JwtTokenProvider {
+
+    @Value("${jwt.secret}")
+    private String secret;
+
+    @Value("${jwt.access-token-validity-ms}")
+    private long accessTokenValidityMs;
+
+    @Value("${jwt.refresh-token-validity-ms}")
+    private long refreshTokenValidityMs;
+
+    private Key key;
+
+    @PostConstruct
+    public void init() {
+        this.key = Keys.hmacShaKeyFor(secret.getBytes());
+    }
+
+    public String createAccessToken(User user) {
+        return createToken(user, accessTokenValidityMs);
+    }
+
+    public String createRefreshToken(User user) {
+        return createToken(user, refreshTokenValidityMs);
+    }
+
+    private String createToken(User user, long validityMs) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + validityMs);
+
+        return Jwts.builder()
+                .setSubject(user.getId().toString())
+                .claim("username", user.getUsername())
+                .claim("role", user.getRole())
+                .setIssuedAt(now)
+                .setExpiration(expiry)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+}


### PR DESCRIPTION
### 🛠 Work Summary

Removed DataSourceAutoConfiguration and HibernateJpaAutoConfiguration exclusions to enable default DB integration

Added JWT and Redis dependencies in build.gradle

Created User entity with fields: id, username, password, email, and role

Added RegisterRequestDto, RegisterResponseDto including embedded UserInfo

Implemented user registration logic in UserService
* Validates duplicate username/email
* Encodes password with BCryptPasswordEncoder
* Generates access and refresh tokens using JwtTokenProvider
* Stores refresh token in Redis

Added user registration endpoint in UserController

Configured SecurityConfig with CORS support and public routes

Implemented JwtTokenProvider for issuing signed tokens with user info

* * *

### ✅ How to Test

Successfully tested the /api/v1/auth/register endpoint with valid input and received a response containing accessToken, refreshToken, and user info.

Decoded the accessToken using [jwt.io](https://jwt.io/) and verified that it contains the correct sub, username, and role claims.

* * *

### 🚩 Notes

Spring Security is configured with CORS and CSRF disabled for simplicity

spring.jpa.open-in-view is enabled by default — may need to be reviewed in production

This closes #4 